### PR TITLE
Fix port_map stanza typo in redis.nomad job spec

### DIFF
--- a/hashistack/part_2_hashistack/playbooks/apps/redis.nomad
+++ b/hashistack/part_2_hashistack/playbooks/apps/redis.nomad
@@ -15,7 +15,7 @@ job "example" {
         image = "redis:3.2"
         network_mode = "bridge"
         port_map {
-          sampleservicedbport = 6379
+          sampleservicedb_port = 6379
         }
         labels {
           group = "label_db"


### PR DESCRIPTION
Old: sampleservicedbport = 6379
New: sampleservicedb_port = 6379

Addresses Issue #4 

Background:  https://github.com/hashicorp/nomad/issues/7532