### PR TITLE
Add bash shell

### DIFF
--- a/hashistack/part_2_hashistack/ansible/Dockerfile
+++ b/hashistack/part_2_hashistack/ansible/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine:latest
 # Install dependencies
 RUN apk update && \
     apk upgrade &&  \
-    apk add --no-cache --update ansible libffi-dev py-netaddr openssh sshpass zip
+    apk add --no-cache --update ansible bash libffi-dev py-netaddr openssh sshpass zip
 # Initialize
 RUN mkdir -p /etc/ansible
 RUN mkdir -p /playbooks


### PR DESCRIPTION
Installing bash into ansible container prevents this issue:
https://github.com/ansible-community/ansible-vault/issues/151