### PR TITLE
Update ansible Dockerfile to include pip

### DIFF
--- a/hashistack/part_2_hashistack/ansible/Dockerfile
+++ b/hashistack/part_2_hashistack/ansible/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine:latest
 # Install dependencies
 RUN apk update && \
     apk upgrade &&  \
-    apk add --no-cache --update ansible bash libffi-dev py-netaddr openssh sshpass zip
+    apk add --no-cache --update ansible bash libffi-dev py-netaddr py3-pip py3-setuptools openssh sshpass zip
 # Initialize
 RUN mkdir -p /etc/ansible
 RUN mkdir -p /playbooks


### PR DESCRIPTION
I had some errors deploying the stack.  These were resolved by adding `py3-pip` and `py3-setuptools` to the ansible container.